### PR TITLE
Fix runspace disposal

### DIFF
--- a/Kestrel/KestrelLib/KestrelServer.cs
+++ b/Kestrel/KestrelLib/KestrelServer.cs
@@ -116,7 +116,7 @@ namespace KestrelLib
                     var inputJson = JsonSerializer.Serialize(request);
 
                     using PowerShell ps = PowerShell.Create();
-                    var rs = RunspaceFactory.CreateRunspace();
+                    using var rs = RunspaceFactory.CreateRunspace();
                     rs.Open();
                     // rs.SessionStateProxy.SetVariable("RequestJson", inputJson);
                     rs.SessionStateProxy.SetVariable("Request", request);
@@ -157,7 +157,7 @@ namespace KestrelLib
                 var inputJson = JsonSerializer.Serialize(request);
 
                 using PowerShell ps = PowerShell.Create();
-                var rs = RunspaceFactory.CreateRunspace();
+                using var rs = RunspaceFactory.CreateRunspace();
                 rs.Open();
                 rs.SessionStateProxy.SetVariable("RequestJson", inputJson);
                 rs.SessionStateProxy.SetVariable("SharedHash", sharedState);


### PR DESCRIPTION
## Summary
- dispose PowerShell runspaces when adding routes

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687110c6af5483209476b5d0f328d60c