### PR TITLE
Add XML docs across repository

### DIFF
--- a/src/Kestrun/KestrunLib/BuildError.cs
+++ b/src/Kestrun/KestrunLib/BuildError.cs
@@ -5,9 +5,17 @@ using Serilog;
 
 namespace KestrunLib
 {
+    /// <summary>
+    /// Helper methods for formatting and returning PowerShell build errors.
+    /// </summary>
     static class BuildError
     {
-
+        /// <summary>
+        /// Creates a text response containing the formatted error output from a
+        /// <see cref="PowerShell"/> instance.
+        /// </summary>
+        /// <param name="ps">PowerShell instance whose streams contain the errors.</param>
+        /// <returns>An <see cref="IResult"/> containing the error text with HTTP status 500.</returns>
         static public IResult Result(PowerShell ps)
         {
             // 500 + text body
@@ -16,6 +24,12 @@ namespace KestrunLib
 
 
 
+        /// <summary>
+        /// Formats all output streams from the provided <see cref="PowerShell"/>
+        /// into a single human readable string.
+        /// </summary>
+        /// <param name="ps">PowerShell instance whose stream contents will be read.</param>
+        /// <returns>Formatted error text containing errors, warnings and verbose messages.</returns>
         static public string Text(PowerShell ps)
         {
             ArgumentNullException.ThrowIfNull(ps);
@@ -57,7 +71,13 @@ namespace KestrunLib
             return msg;
         }
 
-        // Helper that writes the error to the response stream
+        /// <summary>
+        /// Writes the formatted PowerShell error output directly to an
+        /// <see cref="HttpContext"/> response with status code 500.
+        /// </summary>
+        /// <param name="context">The current HTTP context.</param>
+        /// <param name="ps">The PowerShell instance containing error information.</param>
+        /// <returns>A task that completes when the response body has been written.</returns>
         static public Task ResponseAsync(HttpContext context, PowerShell ps)
         {
             var errText = BuildError.Text(ps);               // plain string

--- a/src/Kestrun/KestrunLib/GlobalVariables.cs
+++ b/src/Kestrun/KestrunLib/GlobalVariables.cs
@@ -2,12 +2,23 @@ using System.Collections.Concurrent;
 
 namespace KestrumLib
 {
+    /// <summary>
+    /// Thread-safe store for arbitrary global variables used within Kestrun.
+    /// </summary>
     public static class GlobalVariables
     {
         private record GlobalEntry(object Value, Type Type, bool ReadOnly);
 
         private static readonly ConcurrentDictionary<string, GlobalEntry> _store = new();
 
+        /// <summary>
+        /// Defines a new global variable or updates an existing one.
+        /// </summary>
+        /// <typeparam name="T">Type of the value being stored.</typeparam>
+        /// <param name="name">Variable name.</param>
+        /// <param name="value">Value to store.</param>
+        /// <param name="readOnly">Whether the variable is read-only.</param>
+        /// <returns>True if a new variable was created, false if an existing one was updated.</returns>
         public static bool Define<T>(string name, T value, bool readOnly = false)
         {
 
@@ -29,6 +40,13 @@ namespace KestrumLib
                 }) == entry;
         }
 
+        /// <summary>
+        /// Attempts to retrieve a global variable and cast it to the specified type.
+        /// </summary>
+        /// <typeparam name="T">Expected type of the variable.</typeparam>
+        /// <param name="name">Variable name.</param>
+        /// <param name="value">When this method returns, contains the variable value if found and of the correct type.</param>
+        /// <returns>True if the variable exists and is of the correct type.</returns>
         public static bool TryGet<T>(string name, out T? value)
         {
             if (_store.TryGetValue(name, out var entry) && entry.Value is T typed)
@@ -40,32 +58,62 @@ namespace KestrumLib
             return false;
         }
 
+        /// <summary>
+        /// Gets the raw value of a global variable if it exists.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <returns>The stored value or <c>null</c> if not defined.</returns>
         public static object? Get(string name)
             => _store.TryGetValue(name, out var entry) ? entry.Value : null;
 
+        /// <summary>
+        /// Gets the declared type of a global variable.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <returns>The stored type or <c>null</c> if the variable does not exist.</returns>
         public static Type? GetTypeOf(string name)
             => _store.TryGetValue(name, out var entry) ? entry.Type : null;
 
+        /// <summary>
+        /// Determines whether a global variable is read-only.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <returns><c>true</c> if the variable exists and is read-only.</returns>
         public static bool IsReadOnly(string name)
             => _store.TryGetValue(name, out var entry) && entry.ReadOnly;
 
+        /// <summary>
+        /// Removes a global variable if it exists and is not read-only.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <returns>True if the variable was removed.</returns>
         public static bool Remove(string name)
         {
             if (_store.TryGetValue(name, out var entry) && entry.ReadOnly)
                 return false;
             return _store.TryRemove(name, out _);
         }
+        /// <summary>
+        /// Returns a read-only dictionary of all variable names and their values.
+        /// </summary>
         public static IReadOnlyDictionary<string, object?> GetAllValues()
         {
             return _store.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value.Value);
         }
 
+        /// <summary>
+        /// Creates a snapshot of all variables including their types and read-only flag.
+        /// </summary>
+        /// <returns>A dictionary mapping names to value/type/readOnly tuples.</returns>
         public static IReadOnlyDictionary<string, (object Value, Type Type, bool ReadOnly)> Snapshot()
             => _store.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Value, kvp.Value.Type, kvp.Value.ReadOnly));
 
         /// <summary>
-        /// If the variable exists and is not read-only, overwrite its Value (preserving its original Type & ReadOnly flag).
+        /// Updates the value of an existing variable without changing its type or read-only state.
         /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <param name="newValue">New value to store.</param>
+        /// <returns>True if the value was updated.</returns>
         public static bool UpdateValue(string name, object? newValue)
         {
             return _store.AddOrUpdate(

--- a/src/Kestrun/KestrunLib/HttpVerb.cs
+++ b/src/Kestrun/KestrunLib/HttpVerb.cs
@@ -1,5 +1,8 @@
 namespace KestrumLib
 {
+    /// <summary>
+    /// HTTP methods supported by Kestrun.
+    /// </summary>
     public enum HttpVerb
     {
         Get,
@@ -15,6 +18,11 @@ namespace KestrumLib
 
     public static class HttpVerbExtensions
     {
+        /// <summary>
+        /// Converts the <see cref="HttpVerb"/> to its uppercase string representation.
+        /// </summary>
+        /// <param name="v">The verb to convert.</param>
+        /// <returns>Uppercase string form of the verb.</returns>
         public static string ToMethodString(this HttpVerb v) => v.ToString().ToUpperInvariant();
     }
 }

--- a/src/Kestrun/KestrunLib/KestrunHost.cs
+++ b/src/Kestrun/KestrunLib/KestrunHost.cs
@@ -58,6 +58,12 @@ namespace KestrumLib
 
         // Accepts optional module paths (from PowerShell)
         #region Constructor
+        /// <summary>
+        /// Creates a new Kestrun host instance.
+        /// </summary>
+        /// <param name="appName">Optional application name used for logging.</param>
+        /// <param name="kestrunRoot">Root directory where scripts are located.</param>
+        /// <param name="modulePathsObj">Additional PowerShell module paths.</param>
         public KestrunHost(string? appName = null, string? kestrunRoot = null, string[]? modulePathsObj = null)
         {
             KestrunRoot = kestrunRoot ?? Directory.GetCurrentDirectory();
@@ -141,6 +147,9 @@ namespace KestrumLib
         private List<ListenerOptions>? _listenerOptions;
 
 
+        /// <summary>
+        /// Adds a listener for the specified port and IP address.
+        /// </summary>
         public void ConfigureListener(int port, IPAddress? ipAddress = null, X509Certificate2? x509Certificate = null, HttpProtocols protocols = HttpProtocols.Http1, bool useConnectionLogging = false)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -159,6 +168,9 @@ namespace KestrumLib
 
         }
 
+        /// <summary>
+        /// Convenience overload that configures an HTTP listener without TLS.
+        /// </summary>
         public void ConfigureListener(int port, IPAddress? ipAddress = null, bool useConnectionLogging = false)
         {
             ConfigureListener(port: port, ipAddress: ipAddress, x509Certificate: null, protocols: HttpProtocols.Http1, useConnectionLogging: useConnectionLogging);
@@ -196,6 +208,10 @@ namespace KestrumLib
         #region Python
 
 
+        /// <summary>
+        /// Sets the path to the Python runtime DLL used by Python.NET.
+        /// </summary>
+        /// <param name="path">Full filesystem path to pythonXY.dll.</param>
         static public void ConfigurePythonRuntimePath(string path)
         {
             Python.Runtime.Runtime.PythonDLL = path;
@@ -592,6 +608,9 @@ namespace KestrumLib
         #region Route
         public delegate Task KestrunHandler(KestrunRequest req, KestrunResponse res);
 
+        /// <summary>
+        /// Adds a native .NET route handler for a single HTTP verb.
+        /// </summary>
         public void AddNativeRoute(string pattern, HttpVerb httpVerb, KestrunHandler handler)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -599,6 +618,9 @@ namespace KestrumLib
             AddNativeRoute(pattern: pattern, httpVerbs: [httpVerb], handler: handler);
         }
 
+        /// <summary>
+        /// Adds a native .NET route handler supporting multiple HTTP verbs.
+        /// </summary>
         public void AddNativeRoute(string pattern, IEnumerable<HttpVerb> httpVerbs, KestrunHandler handler)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -615,16 +637,22 @@ namespace KestrumLib
             });
         }
 
+        /// <summary>
+        /// Adds a script-based route for a single HTTP verb.
+        /// </summary>
         public void AddRoute(string pattern,
                                          HttpVerb httpVerbs,
-                                           string scriptBlock,
-                                           ScriptLanguage language = ScriptLanguage.PowerShell,
-                                           string[]? extraImports = null,
-                                           Assembly[]? extraRefs = null)
+                                          string scriptBlock,
+                                          ScriptLanguage language = ScriptLanguage.PowerShell,
+                                          string[]? extraImports = null,
+                                          Assembly[]? extraRefs = null)
         {
             AddRoute(pattern, [httpVerbs], scriptBlock, language, extraImports, extraRefs);
         }
 
+        /// <summary>
+        /// Adds a script-based route supporting multiple HTTP verbs.
+        /// </summary>
         public void AddRoute(string pattern,
                                     IEnumerable<HttpVerb> httpVerbs,
                                     string scriptBlock,
@@ -680,11 +708,17 @@ namespace KestrumLib
 
         #endregion
         #region Configuration
+        /// <summary>
+        /// Stores Kestrel configuration options to be applied later.
+        /// </summary>
         public void ConfigureKestrel(KestrunOptions options)
         {
             _kestrelOptions = options;
         }
 
+        /// <summary>
+        /// Applies previously configured options and initializes services.
+        /// </summary>
         public void ApplyConfiguration()
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -696,6 +730,9 @@ namespace KestrumLib
             ApplyConfiguration(_kestrelOptions);
         }
 
+        /// <summary>
+        /// Applies the specified options to the underlying web host.
+        /// </summary>
         public void ApplyConfiguration(KestrunOptions options)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -776,6 +813,9 @@ namespace KestrumLib
         #endregion
         #region Run/Start/Stop
 
+        /// <summary>
+        /// Runs the web application using the configured options.
+        /// </summary>
         public void Run()
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -785,6 +825,9 @@ namespace KestrumLib
             App?.Run();
         }
 
+        /// <summary>
+        /// Starts the web application without blocking the calling thread.
+        /// </summary>
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -796,6 +839,9 @@ namespace KestrumLib
             }
         }
 
+        /// <summary>
+        /// Stops the web application gracefully.
+        /// </summary>
         public async Task StopAsync(CancellationToken cancellationToken = default)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -806,6 +852,9 @@ namespace KestrumLib
             }
         }
 
+        /// <summary>
+        /// Requests the application to stop.
+        /// </summary>
         public void Stop()
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -932,6 +981,9 @@ namespace KestrumLib
 
         #region Disposable
 
+        /// <summary>
+        /// Disposes the runspace pool and releases resources.
+        /// </summary>
         public void Dispose()
         {
             if (Log.IsEnabled(LogEventLevel.Debug))

--- a/src/Kestrun/KestrunLib/KestrunRequest.cs
+++ b/src/Kestrun/KestrunLib/KestrunRequest.cs
@@ -1,5 +1,8 @@
 namespace KestrumLib
 {
+    /// <summary>
+    /// Simplified representation of an incoming HTTP request used by script handlers.
+    /// </summary>
     public class KestrunRequest
     {
         public required string Method { get; set; }
@@ -8,6 +11,11 @@ namespace KestrumLib
         public required Dictionary<string, string> Headers { get; set; }
         public required string Body { get; set; }
 
+        /// <summary>
+        /// Creates a <see cref="KestrunRequest"/> from the provided <see cref="HttpContext"/>.
+        /// </summary>
+        /// <param name="context">The current HTTP context.</param>
+        /// <returns>A populated <see cref="KestrunRequest"/> instance.</returns>
         static public async Task<KestrunRequest> NewRequest(HttpContext context)
         {
             using var reader = new StreamReader(context.Request.Body);

--- a/src/Kestrun/KestrunLib/KestrunResponse.cs
+++ b/src/Kestrun/KestrunLib/KestrunResponse.cs
@@ -14,6 +14,9 @@ using Microsoft.AspNetCore.WebUtilities;
 namespace KestrumLib
 {
 
+    /// <summary>
+    /// Represents common values for the Content-Disposition response header.
+    /// </summary>
     public enum ContentDispositionType
     {
         Attachment,
@@ -21,7 +24,7 @@ namespace KestrumLib
         NoContentDisposition
     }
     /// <summary>
-    /// Options for Content-Disposition header.
+    /// Options for the Content-Disposition response header.
     /// </summary>
     public struct ContentDispositionOptions
     {
@@ -34,6 +37,9 @@ namespace KestrumLib
         public string? FileName { get; set; }
         public ContentDispositionType Type { get; set; }
     }
+    /// <summary>
+    /// Represents an HTTP response that can be written by script handlers.
+    /// </summary>
     public class KestrunResponse
     {
 
@@ -69,6 +75,11 @@ namespace KestrumLib
         public int BodyAsyncThreshold { get; set; } = 8192; // 8 KB default
 
         #region Constructors
+        /// <summary>
+        /// Initializes a new instance of <see cref="KestrunResponse"/> for the specified request.
+        /// </summary>
+        /// <param name="request">Originating request.</param>
+        /// <param name="bodyAsyncThreshold">Threshold in bytes above which the body is written asynchronously.</param>
         public KestrunResponse(KestrunRequest request, int bodyAsyncThreshold = 8192)
         {
             Request = request ?? throw new ArgumentNullException(nameof(request));
@@ -78,11 +89,22 @@ namespace KestrumLib
         #endregion
 
         #region Helpers
+        /// <summary>
+        /// Retrieves a previously set response header value.
+        /// </summary>
+        /// <param name="key">Header name.</param>
+        /// <returns>The header value if present; otherwise <c>null</c>.</returns>
         public string? GetHeader(string key)
         {
             return Headers.TryGetValue(key, out var value) ? value : null;
         }
 
+        /// <summary>
+        /// Determines the response content type based on an explicit value or the Accept header.
+        /// </summary>
+        /// <param name="contentType">Explicit content type if provided.</param>
+        /// <param name="defaultType">Default type to use when none is specified.</param>
+        /// <returns>The chosen content type string.</returns>
         private string DetermineContentType(string? contentType, string defaultType = "text/plain")
         {
             if (string.IsNullOrWhiteSpace(contentType))
@@ -121,6 +143,12 @@ namespace KestrumLib
         #endregion
 
         #region  Response Writers
+        /// <summary>
+        /// Writes a file to the response and sets appropriate headers.
+        /// </summary>
+        /// <param name="filePath">Path to the file on disk.</param>
+        /// <param name="contentType">Optional MIME type override.</param>
+        /// <param name="statusCode">HTTP status code to send.</param>
         public void WriteFileResponse(
             string? filePath,
             string? contentType,
@@ -166,11 +194,23 @@ namespace KestrumLib
             ContentDisposition.Type = ContentDispositionType.Attachment;
         }
 
+        /// <summary>
+        /// Serializes the given object to JSON and writes it to the response body.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="statusCode">HTTP status code to send.</param>
         public void WriteJsonResponse(object? inputObject, int statusCode = StatusCodes.Status200OK)
         {
             WriteJsonResponse(inputObject, depth: 10, compress: false, statusCode: statusCode);
         }
 
+        /// <summary>
+        /// Serializes the object to JSON using custom serializer settings.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="serializerSettings">Settings controlling JSON serialization.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">Optional content type override.</param>
         public void WriteJsonResponse(object? inputObject, JsonSerializerSettings serializerSettings, int statusCode = StatusCodes.Status200OK, string? contentType = null)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -181,6 +221,11 @@ namespace KestrumLib
             StatusCode = statusCode;
         }
 
+        /// <summary>
+        /// Writes a response in a format determined by the Accept header.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="statusCode">HTTP status code.</param>
         public void WriteResponse(object? inputObject, int statusCode = StatusCodes.Status200OK)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -207,6 +252,14 @@ namespace KestrumLib
             }
         }
 
+        /// <summary>
+        /// Writes JSON to the response with advanced options.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="depth">Maximum JSON depth.</param>
+        /// <param name="compress">Whether to omit whitespace.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">Optional content type override.</param>
         public void WriteJsonResponse(object? inputObject, int depth, bool compress, int statusCode = StatusCodes.Status200OK, string? contentType = null)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -225,6 +278,12 @@ namespace KestrumLib
             WriteJsonResponse(inputObject, serializerSettings: serializerSettings, statusCode: statusCode, contentType: contentType);
         }
 
+        /// <summary>
+        /// Serializes the object to YAML and writes it to the response.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">Optional content type override.</param>
         public void WriteYamlResponse(object? inputObject, int statusCode = StatusCodes.Status200OK, string? contentType = null)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -235,6 +294,12 @@ namespace KestrumLib
             StatusCode = statusCode;
         }
 
+        /// <summary>
+        /// Serializes the object to XML and writes it to the response body.
+        /// </summary>
+        /// <param name="inputObject">Object to serialize.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">Optional content type override.</param>
         public void WriteXmlResponse(object? inputObject, int statusCode = StatusCodes.Status200OK, string? contentType = null)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -247,6 +312,12 @@ namespace KestrumLib
             StatusCode = statusCode;
         }
 
+        /// <summary>
+        /// Writes a plain text response using <c>ToString()</c> on the object.
+        /// </summary>
+        /// <param name="inputObject">Object to output.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">Optional content type override.</param>
         public void WriteTextResponse(object? inputObject, int statusCode = StatusCodes.Status200OK, string? contentType = null)
         {
 
@@ -261,6 +332,11 @@ namespace KestrumLib
             StatusCode = statusCode;
         }
 
+        /// <summary>
+        /// Issues a 302 redirect to the specified URL.
+        /// </summary>
+        /// <param name="url">Destination URL.</param>
+        /// <param name="message">Optional response body.</param>
         public void WriteRedirectResponse(string url, string? message = null)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -290,6 +366,12 @@ namespace KestrumLib
             }
 
         }
+        /// <summary>
+        /// Writes raw binary data to the response body.
+        /// </summary>
+        /// <param name="data">Byte array to send.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">MIME type of the data.</param>
         public void WriteBinaryResponse(byte[] data, int statusCode = StatusCodes.Status200OK, string contentType = "application/octet-stream")
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -300,6 +382,12 @@ namespace KestrumLib
             //       Headers["Content-Length"] = data.Length.ToString();
         }
 
+        /// <summary>
+        /// Writes the contents of a stream to the response body.
+        /// </summary>
+        /// <param name="stream">Stream to copy to the response.</param>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="contentType">MIME type for the stream contents.</param>
         public void WriteStreamResponse(Stream stream, int statusCode = StatusCodes.Status200OK, string contentType = "application/octet-stream")
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -447,6 +535,11 @@ namespace KestrumLib
         }
         #endregion
         #region Apply to HttpResponse
+        /// <summary>
+        /// Applies this response to an <see cref="HttpResponse"/> instance.
+        /// </summary>
+        /// <param name="response">The ASP.NET response to write to.</param>
+        /// <returns>A task that completes when the response has been flushed.</returns>
         public async Task ApplyTo(HttpResponse response)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))

--- a/src/Kestrun/KestrunLib/LanguageRuntimeExtensions.cs
+++ b/src/Kestrun/KestrunLib/LanguageRuntimeExtensions.cs
@@ -18,8 +18,13 @@ namespace KestrumLib
 
     public static class LanguageRuntimeExtensions
     {
-        /// Adds <see cref="configure"/> to a sub-pipeline that runs
-        /// only when the resolved endpoint is tagged with the given language.
+        /// <summary>
+        /// Adds <paramref name="configure"/> to a sub-pipeline that runs only when
+        /// the resolved endpoint is tagged with the specified language.
+        /// </summary>
+        /// <param name="app">Application builder.</param>
+        /// <param name="language">Language tag to filter on.</param>
+        /// <param name="configure">Callback to configure the sub-pipeline.</param>
         public static IApplicationBuilder UseLanguageRuntime(
             this IApplicationBuilder app,
             ScriptLanguage language,

--- a/src/Kestrun/KestrunLib/ListenerOptions.cs
+++ b/src/Kestrun/KestrunLib/ListenerOptions.cs
@@ -5,15 +5,27 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace KestrumLib
 {
+    /// <summary>
+    /// Options for configuring an individual HTTP listener in Kestrun.
+    /// </summary>
     public class ListenerOptions
     {
+        /// <summary>IP address to bind to.</summary>
         public IPAddress IPAddress { get; set; }
+        /// <summary>TCP port to listen on.</summary>
         public int Port { get; set; }
+        /// <summary>Whether HTTPS should be used.</summary>
         public bool UseHttps { get; set; }
-        public HttpProtocols Protocols { get; set; } 
+        /// <summary>HTTP protocols supported by this listener.</summary>
+        public HttpProtocols Protocols { get; set; }
+        /// <summary>Enables connection logging middleware.</summary>
         public bool UseConnectionLogging { get; set; }
+        /// <summary>Certificate used for TLS termination when <see cref="UseHttps"/> is true.</summary>
         public X509Certificate2? X509Certificate { get; internal set; }
 
+        /// <summary>
+        /// Creates a new instance with sensible defaults.
+        /// </summary>
         public ListenerOptions()
         {
             IPAddress = IPAddress.Any;

--- a/src/Kestrun/KestrunLib/NoopHostLifetime.cs
+++ b/src/Kestrun/KestrunLib/NoopHostLifetime.cs
@@ -1,8 +1,13 @@
 namespace KestrumLib
 {
+    /// <summary>
+    /// Minimal <see cref="IHostLifetime"/> implementation used when hosting inside another application.
+    /// </summary>
     public class NoopHostLifetime : IHostLifetime
     {
+        /// <inheritdoc />
         public Task WaitForStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        /// <inheritdoc />
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/Kestrun/KestrunLib/PSLog.cs
+++ b/src/Kestrun/KestrunLib/PSLog.cs
@@ -1,12 +1,21 @@
 namespace KestrumLib
 {
+    /// <summary>
+    /// Simple wrapper around Serilog that matches the cmdlet style logging API.
+    /// </summary>
     public class PSLog
     {
+        /// <summary>Logs a debug message.</summary>
         public void Debug(string message, params object[] args)      => Serilog.Log.Debug(message, args);
+        /// <summary>Logs a verbose message.</summary>
         public void Verbose(string message, params object[] args)    => Serilog.Log.Verbose(message, args);
+        /// <summary>Logs an informational message.</summary>
         public void Information(string message, params object[] args)=> Serilog.Log.Information(message, args);
+        /// <summary>Logs a warning message.</summary>
         public void Warning(string message, params object[] args)    => Serilog.Log.Warning(message, args);
+        /// <summary>Logs an error message.</summary>
         public void Error(string message, params object[] args)      => Serilog.Log.Error(message, args);
+        /// <summary>Logs a fatal message.</summary>
         public void Fatal(string message, params object[] args)      => Serilog.Log.Fatal(message, args);
     }
 }

--- a/src/Kestrun/KestrunLib/PowerShellRunspaceMiddlewareExtensions.cs
+++ b/src/Kestrun/KestrunLib/PowerShellRunspaceMiddlewareExtensions.cs
@@ -2,8 +2,16 @@ using System.Management.Automation.Runspaces;
 using static KestrumLib.KestrunHost;
 namespace KestrumLib
 {
+    /// <summary>
+    /// Extension methods for adding PowerShell runspace middleware to the ASP.NET pipeline.
+    /// </summary>
     public static class PowerShellRunspaceMiddlewareExtensions
     {
+        /// <summary>
+        /// Registers middleware that provides a pooled PowerShell runspace to each request.
+        /// </summary>
+        /// <param name="app">Application builder.</param>
+        /// <param name="pool">Runspace pool to use for script execution.</param>
         public static IApplicationBuilder UsePowerShellRunspace(
             this IApplicationBuilder app, RunspacePool pool)
         {

--- a/src/Kestrun/KestrunLib/ScriptLanguage.cs
+++ b/src/Kestrun/KestrunLib/ScriptLanguage.cs
@@ -1,11 +1,19 @@
 namespace KestrumLib
 {
+    /// <summary>
+    /// Languages supported for route handlers.
+    /// </summary>
     public enum ScriptLanguage
     {
+        /// <summary>PowerShell scripting language.</summary>
         PowerShell,
+        /// <summary>C# scripting.</summary>
         CSharp,
+        /// <summary>F# scripting (not yet implemented).</summary>
         FSharp,
+        /// <summary>Python scripting via Python.NET.</summary>
         Python,
-        JavaScript        // optional – ClearScript/Jint
+        /// <summary>JavaScript using ClearScript or Jint.</summary>
+        JavaScript
     }
 }

--- a/src/Kestrun/KestrunLib/XmlUtil.cs
+++ b/src/Kestrun/KestrunLib/XmlUtil.cs
@@ -7,10 +7,19 @@ using System.Xml.Linq;
 
 namespace KestrumLib;
 
+/// <summary>
+/// Helper for converting arbitrary objects into simple XML representations.
+/// </summary>
 public static class XmlUtil
 {
     private static readonly XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
 
+    /// <summary>
+    /// Converts any .NET object into an <see cref="XElement"/>.
+    /// </summary>
+    /// <param name="name">Element name.</param>
+    /// <param name="value">Object to serialize.</param>
+    /// <returns>An <see cref="XElement"/> representing the value.</returns>
     public static XElement ToXml(string name, object? value)
     {
         // 1️⃣ null  → <name xsi:nil="true"/>

--- a/src/Kestrun/KestrunLib/YamlHelper.cs
+++ b/src/Kestrun/KestrunLib/YamlHelper.cs
@@ -8,6 +8,9 @@ using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 namespace KestrumLib
 {
+    /// <summary>
+    /// Utility methods for converting objects to and from YAML.
+    /// </summary>
     public static class YamlHelper
     {
         private static readonly ISerializer _serializer = new SerializerBuilder()
@@ -18,21 +21,31 @@ namespace KestrumLib
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .Build();
 
-        // Serialize any PowerShell object to YAML
+        /// <summary>
+        /// Serializes any PowerShell object to YAML.
+        /// </summary>
+        /// <param name="input">Object to serialize.</param>
+        /// <returns>YAML string representing the object.</returns>
         public static string ToYaml(object? input)
         {
             var normalized = NormalizePSObject(input);
             return _serializer.Serialize(normalized);
         }
 
-        // Deserialize YAML into Hashtable
+        /// <summary>
+        /// Deserializes YAML into a <see cref="Hashtable"/>.
+        /// </summary>
+        /// <param name="yaml">YAML text.</param>
         public static Hashtable FromYamlToHashtable(string yaml)
         {
             var obj = _deserializer.Deserialize<object>(yaml);
             return (Hashtable)ConvertToPSCompatible(obj);
         }
 
-        // Deserialize YAML into PSCustomObject
+        /// <summary>
+        /// Deserializes YAML into a <see cref="PSObject"/>.
+        /// </summary>
+        /// <param name="yaml">YAML text.</param>
         public static PSObject FromYamlToPSCustomObject(string yaml)
         {
             var obj = _deserializer.Deserialize<object>(yaml);


### PR DESCRIPTION
## Summary
- add XML documentation to many public methods across the library
- document helpers in `BuildError`, `GlobalVariables`, `HttpVerb`, `Kestrun*` classes and others
- provide docs for certificate utilities, YAML helpers and response helpers

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879765ef8a08320bd22c5447128ee8d