### PR TITLE
Add PowerShell module tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,3 +25,8 @@ jobs:
       with:
         dotnet-version: '8.0.x'
     - run: dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build
+    - name: Run PowerShell tests
+      shell: pwsh
+      run: |
+        Install-Module Pester -Force -Scope CurrentUser
+        Invoke-Pester -CI -Path tests/PowerShell.Tests

--- a/README.md
+++ b/README.md
@@ -16,4 +16,11 @@ Tests are written with `xUnit` under `tests/KestrunLib.Tests`. To execute them l
 dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj
 ```
 
+PowerShell module tests live under `tests/PowerShell.Tests` and use Pester.
+Run them locally with:
+
+```powershell
+pwsh -NoLogo -Command "Invoke-Pester -CI -Path tests/PowerShell.Tests"
+```
+
 A GitHub Actions workflow runs these tests automatically on every push and pull request.

--- a/tests/PowerShell.Tests/KestrunModule.Tests.ps1
+++ b/tests/PowerShell.Tests/KestrunModule.Tests.ps1
@@ -1,0 +1,26 @@
+$modulePath = Join-Path $PSScriptRoot '..' '..' 'src' 'Kestrun.psd1'
+
+Describe 'Kestrun PowerShell Module' {
+    BeforeAll {
+        Import-Module $modulePath -Force
+    }
+
+    AfterAll {
+        Remove-Module Kestrun -Force
+    }
+
+    It 'Exports Set-KrGlobalVar command' {
+        Get-Command Set-KrGlobalVar | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Can define and retrieve a global variable' {
+        Set-KrGlobalVar -Name 'psTestVar' -Value @(1,2,3)
+        (Get-KrGlobalVar -Name 'psTestVar').Count | Should -Be 3
+    }
+
+    It 'Can remove a global variable' {
+        Set-KrGlobalVar -Name 'psToRemove' -Value @()
+        Remove-KrGlobalVar -Name 'psToRemove'
+        [KestrumLib.GlobalVariables]::TryGet('psToRemove', [ref]$null) | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for the PowerShell module
- run PowerShell tests in CI
- document how to run new tests

## Testing
- `dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b755539c83209b99763f120e1cdb