### PR TITLE
Add PowerShell module tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,3 +25,8 @@ jobs:
       with:
         dotnet-version: '8.0.x'
     - run: dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build
+    - name: Run PowerShell tests
+      shell: pwsh
+      run: |
+        Install-Module Pester -Force -Scope CurrentUser
+        Invoke-Pester -CI -Path tests/PowerShell.Tests

--- a/README.md
+++ b/README.md
@@ -16,4 +16,14 @@ Tests are written with `xUnit` under `tests/KestrunLib.Tests`. To execute them l
 dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj
 ```
 
+PowerShell module tests live under `tests/PowerShell.Tests` and use Pester.
+Run them locally with:
+
+```powershell
+pwsh -NoLogo -Command "Invoke-Pester -CI -Path tests/PowerShell.Tests"
+```
+
+The suite exercises the module's exported commands such as the global
+variable helpers, path resolution and response writers.
+
 A GitHub Actions workflow runs these tests automatically on every push and pull request.

--- a/tests/PowerShell.Tests/KestrunModule.Tests.ps1
+++ b/tests/PowerShell.Tests/KestrunModule.Tests.ps1
@@ -1,0 +1,54 @@
+$publicRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'Public'
+
+Describe 'Kestrun PowerShell Functions' {
+    BeforeAll {
+        if (-not ('KestrumLib.GlobalVariables' -as [type])) {
+            Add-Type -Language CSharp -TypeDefinition @"
+namespace KestrumLib {
+    public static class GlobalVariables {
+        private static readonly System.Collections.Generic.Dictionary<string, object> Table = new();
+        public static bool Define(string name, object value, bool readOnly) {
+            if (readOnly && Table.ContainsKey(name)) return false;
+            Table[name] = value; return true;
+        }
+        public static object Get(string name) => Table.TryGetValue(name, out var v) ? v : null;
+        public static bool Remove(string name) => Table.Remove(name);
+        public static bool TryGet(string name, out object value) => Table.TryGetValue(name, out value);
+    }
+}
+"@
+        }
+
+        Get-ChildItem -Path "$publicRoot/*.ps1" | ForEach-Object { . $_.FullName }
+    }
+
+    AfterAll {
+        Remove-Variable Response -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It 'Set-KrGlobalVar defines and retrieves values' {
+        Set-KrGlobalVar -Name 'psTestVar' -Value @(1,2,3)
+        (Get-KrGlobalVar -Name 'psTestVar').Count | Should -Be 3
+    }
+
+    It 'Remove-KrGlobalVar deletes value' {
+        Set-KrGlobalVar -Name 'psToRemove' -Value @()
+        Remove-KrGlobalVar -Name 'psToRemove'
+        [KestrumLib.GlobalVariables]::TryGet('psToRemove', [ref]$null) | Should -BeFalse
+    }
+
+    It 'Resolve-KrPath returns absolute path' {
+        $result = Resolve-KrPath -Path '.' -KestrunRoot
+        [System.IO.Path]::IsPathRooted($result) | Should -BeTrue
+    }
+
+    It 'Write-KrTextResponse calls method on Response object' {
+        $script:called = $null
+        $script:Response = [pscustomobject]@{
+            WriteTextResponse = { param($o,$s,$c) $script:called = "$o|$s|$c" }
+        }
+        Write-KrTextResponse -InputObject 'hi' -StatusCode 201 -ContentType 'text/plain'
+        $script:called | Should -Be 'hi|201|text/plain'
+        Remove-Variable Response -Scope Script
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for PowerShell module functions
- document that tests cover multiple exported commands

## Testing
- `dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build` *(fails: command not found)*
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path tests/PowerShell.Tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b755539c83209b99763f120e1cdb